### PR TITLE
Avoid unnecessary type alias for `(module Thread)`

### DIFF
--- a/src/Domain_local_await.ml
+++ b/src/Domain_local_await.ml
@@ -29,14 +29,7 @@ module Default = struct
       { release; await }
 end
 
-module type Thread = sig
-  type t
-
-  val self : unit -> t
-  val id : t -> int
-end
-
-type 'handle thread = (module Thread with type t = 'handle)
+include Thread_intf
 
 module IdMap = Map.Make (Int)
 
@@ -53,7 +46,7 @@ type config =
 
 let key = Domain.DLS.new_key @@ fun () -> Per_domain (Default.init ())
 
-let per_thread (type handle) ((module Thread) : handle thread) =
+let per_thread ((module Thread) : (module Thread)) =
   match Domain.DLS.get key with
   | Per_thread _ ->
       failwith "Domain_local_await: per_thread called twice on a single domain"

--- a/src/Domain_local_await.mli
+++ b/src/Domain_local_await.mli
@@ -53,19 +53,9 @@ val using : prepare_for_await:(unit -> t) -> while_running:(unit -> 'a) -> 'a
 
 (** {2 Per thread configuration} *)
 
-(** Signature for a minimal subset of the [Stdlib.Thread] module needed by
-    domain local await. *)
-module type Thread = sig
-  type t
+include module type of Thread_intf
 
-  val self : unit -> t
-  val id : t -> int
-end
-
-type 'handle thread = (module Thread with type t = 'handle)
-(** Type alias for a first-class {!Thread} module. *)
-
-val per_thread : 'handle thread -> unit
+val per_thread : (module Thread) -> unit
 (** [per_thread (module Thread)] configures the current domain to store and
     select the trigger mechanism per systhread.  This can be called at most once
     per domain.

--- a/src/Thread_intf.ml
+++ b/src/Thread_intf.ml
@@ -1,0 +1,8 @@
+(** Signature for a minimal subset of the [Stdlib.Thread] module needed by
+    domain local await. *)
+module type Thread = sig
+  type t
+
+  val self : unit -> t
+  val id : t -> int
+end


### PR DESCRIPTION
There isn't really need for the `thread` type alias, so delete it.  Also avoid duplicating the `Thread` signature.  I also tested that Eio, Domainslib, and kcas build after this change.