### PR TITLE
Use `thread-table`

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,9 +2,6 @@ name: build-and-test
 
 on:
   pull_request:
-  push:
-    branches-ignore:
-      - gh-pages
 
 jobs:
   build:
@@ -13,6 +10,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
         ocaml-compiler:
           - 5.0.0
 
@@ -28,4 +26,35 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       - name: Install dependencies
-        run: opam pin . --with-test --yes
+        run: opam install . --deps-only --with-test
+
+      - name: Build
+        run: opam exec -- dune build
+
+      - name: Test
+        run: opam exec -- dune runtest
+
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ocaml.5.0.0,ocaml-option-mingw
+          opam-repositories: |
+            dra27: https://github.com/dra27/opam-repository.git#windows-5.0
+            default: https://github.com/fdopen/opam-repository-mingw.git#opam2
+            standard: https://github.com/ocaml/opam-repository.git
+
+      - name: Install dependencies
+        run: opam install . --deps-only --with-test
+
+      - name: Build
+        run: opam exec -- dune build
+
+      - name: Test
+        run: opam exec -- dune runtest

--- a/domain-local-await.opam
+++ b/domain-local-await.opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/ocaml-multicore/domain-local-await/issues"
 depends: [
   "dune" {>= "3.3"}
   "ocaml" {>= "5.0"}
+  "thread-table" {>= "0.1.0"}
   "mdx" {>= "1.10.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -10,5 +10,6 @@
  (synopsis "A scheduler independent blocking mechanism")
  (depends
   (ocaml (>= 5.0))
+  (thread-table (>= 0.1.0))
   (mdx (and (>= 1.10.0) :with-test))))
 (using mdx 0.2)

--- a/src/Domain_local_await.mli
+++ b/src/Domain_local_await.mli
@@ -58,7 +58,7 @@ include module type of Thread_intf
 val per_thread : (module Thread) -> unit
 (** [per_thread (module Thread)] configures the current domain to store and
     select the trigger mechanism per systhread.  This can be called at most once
-    per domain.
+    per domain before any calls to {!prepare_for_await}.
 
     The reason why this is an opt-in feature is that this allows domain local
     await to be implemented without depending on [Thread] which also depends on

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,4 @@
 (library
  (name Domain_local_await)
- (public_name domain-local-await))
+ (public_name domain-local-await)
+ (libraries thread-table))


### PR DESCRIPTION
This PR changes the per thread configuration to use [thread-table](https://github.com/ocaml-multicore/thread-table), a thread-safe hash table, instead of a map.