### PR TITLE
Support OCaml 4.12.0+

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,9 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ocaml-compiler:
-          - 5.0.0
+          - 4.x
+          - 4.12.0
+          - 5.x
 
     runs-on: ${{ matrix.os }}
 

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,4 @@
 profile = default
 version = 0.25.1
+
+exp-grouping=preserve

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Let's implement a simple awaitable atomic location abstraction. First we need
 the domain local await library:
 
 ```ocaml
+# #thread
 # #require "domain-local-await"
 ```
 
@@ -113,14 +114,8 @@ To test awaitable locations, let's first create a location:
 val x : int awaitable_atomic = <abstr>
 ```
 
-And let's then create a thread
-
-```ocaml
-# #thread
-```
-
-that awaits until the value of the location has changed and then modifies the
-value of the location:
+And let's then create a thread that awaits until the value of the location has
+changed and then modifies the value of the location:
 
 ```ocaml
 # let a_thread =

--- a/domain-local-await.opam
+++ b/domain-local-await.opam
@@ -10,6 +10,7 @@ depends: [
   "dune" {>= "3.3"}
   "ocaml" {>= "4.12.0"}
   "thread-table" {>= "0.1.0"}
+  "alcotest" {>= "1.7.0" & with-test}
   "mdx" {>= "1.10.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/domain-local-await.opam
+++ b/domain-local-await.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/ocaml-multicore/domain-local-await"
 bug-reports: "https://github.com/ocaml-multicore/domain-local-await/issues"
 depends: [
   "dune" {>= "3.3"}
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "4.12.0"}
   "thread-table" {>= "0.1.0"}
   "mdx" {>= "1.10.0" & with-test}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -9,7 +9,7 @@
 (package (name domain-local-await)
  (synopsis "A scheduler independent blocking mechanism")
  (depends
-  (ocaml (>= 5.0))
+  (ocaml (>= 4.12.0))
   (thread-table (>= 0.1.0))
   (mdx (and (>= 1.10.0) :with-test))))
 (using mdx 0.2)

--- a/dune-project
+++ b/dune-project
@@ -11,5 +11,6 @@
  (depends
   (ocaml (>= 4.12.0))
   (thread-table (>= 0.1.0))
+  (alcotest (and (>= 1.7.0) :with-test))
   (mdx (and (>= 1.10.0) :with-test))))
 (using mdx 0.2)

--- a/src/Domain_local_await.ml
+++ b/src/Domain_local_await.ml
@@ -88,10 +88,11 @@ let per_thread ((module Thread) : (module Thread)) =
 
 let using ~prepare_for_await ~while_running =
   match Domain.DLS.get key with
-  | Per_domain _ as previous ->
-      let current = Per_domain { prepare_for_await } in
-      Domain.DLS.set key current;
-      Fun.protect while_running ~finally:(fun () -> Domain.DLS.set key previous)
+  | Per_domain r ->
+      let previous = r.prepare_for_await in
+      r.prepare_for_await <- prepare_for_await;
+      Fun.protect while_running ~finally:(fun () ->
+          r.prepare_for_await <- previous)
   | Per_thread r ->
       let id = r.id (r.self ()) in
       Thread_table.add r.id_to_prepare id prepare_for_await;

--- a/src/domain_fake.ml
+++ b/src/domain_fake.ml
@@ -1,0 +1,5 @@
+module DLS = struct
+  let new_key default = ref (default ())
+  let get = ( ! )
+  let set = ( := )
+end

--- a/src/domain_real.ml
+++ b/src/domain_real.ml
@@ -1,0 +1,1 @@
+module DLS = Stdlib.Domain.DLS

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,26 @@
+(* -*- tuareg -*- *)
+
+let maybe_threads =
+  if Jbuild_plugin.V1.ocaml_version < "5" then "threads" else ""
+
+let () =
+  Jbuild_plugin.V1.send
+  @@ {|
+
 (library
  (name Domain_local_await)
+ (modules domain_local_await thread_intf domain)
  (public_name domain-local-await)
- (libraries thread-table))
+ (libraries thread-table |}
+  ^ maybe_threads
+  ^ {| ))
+
+(rule
+ (enabled_if (< %{ocaml_version} 5.0.0))
+ (action (copy domain_fake.ml domain.ml)))
+
+(rule
+ (enabled_if (>= %{ocaml_version} 5.0.0))
+ (action (copy domain_real.ml domain.ml)))
+
+|}

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries domain-local-await threads))
+ (libraries domain-local-await threads alcotest))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,7 +1,14 @@
+let[@poll error] push_atomically r before after =
+  !r == before
+  && begin
+       r := after;
+       true
+     end
+
 let rec push r x =
   let before = !r in
   let after = x :: before in
-  if !r == before then r := after else push r x
+  if not (push_atomically r before after) then push r x
 
 let test_all_threads_are_woken_up () =
   let n = ref 2 in

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,3 +1,8 @@
+let rec push r x =
+  let before = !r in
+  let after = x :: before in
+  if !r == before then r := after else push r x
+
 let test_all_threads_are_woken_up () =
   let n = ref 2 in
 
@@ -10,7 +15,7 @@ let test_all_threads_are_woken_up () =
     ()
     |> Thread.create @@ fun () ->
        let t = Domain_local_await.prepare_for_await () in
-       awaiters := t.release :: !awaiters;
+       push awaiters t.release;
        decr n;
        if !n = 0 then barrier.release ();
        t.await ()

--- a/test/test.ml
+++ b/test/test.ml
@@ -34,8 +34,11 @@ let test_all_threads_are_woken_up () =
 
   threads |> List.iter Thread.join
 
-let () =
+let basics () =
   test_all_threads_are_woken_up ();
   Domain_local_await.per_thread (module Thread);
-  test_all_threads_are_woken_up ();
-  ()
+  test_all_threads_are_woken_up ()
+
+let () =
+  Alcotest.run "Domain_local_await"
+    [ ("basics", [ Alcotest.test_case "" `Quick basics ]) ]


### PR DESCRIPTION
This PR ports DLA to work with OCaml 4.12.0+.  The reason to require 4.12.0 is that it introduces `Atomic`, which is used in some tests.  That could be avoided with some additional work.

This PR also improves the implementation to avoid allocating a default implementation (mutex and condition) for domains that don't use it.