### PR TITLE
Add `inline never` along with `poll error`

### DIFF
--- a/src/Domain_local_await.ml
+++ b/src/Domain_local_await.ml
@@ -50,10 +50,11 @@ let default () = !default_init ()
 let key =
   Domain.DLS.new_key @@ fun () -> Per_domain { prepare_for_await = default }
 
-(* Below we use [@poll error] to ensure that there are no safe-points where
-   thread switches might occur during critical section. *)
+(* Below we use [@poll error] and [@inline never] to ensure that there are no
+   safe-points where thread switches might occur during critical section. *)
 
-let[@poll error] update_prepare_atomically state prepare_for_await =
+let[@poll error] [@inline never] update_prepare_atomically state
+    prepare_for_await =
   match state with
   | Per_domain r ->
       let current = r.prepare_for_await in

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,4 +1,4 @@
-let[@poll error] push_atomically r before after =
+let[@poll error] [@inline never] push_atomically r before after =
   !r == before
   && begin
        r := after;


### PR DESCRIPTION
`poll error` implies `inline never`, but older compilers do not understand `poll error`.