### PR TITLE
Add example of transparently asynchronous IO

### DIFF
--- a/domain-local-await.opam
+++ b/domain-local-await.opam
@@ -9,11 +9,12 @@ license: "ISC"
 homepage: "https://github.com/ocaml-multicore/domain-local-await"
 bug-reports: "https://github.com/ocaml-multicore/domain-local-await/issues"
 depends: [
-  "dune" {>= "3.3"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.12.0"}
   "thread-table" {>= "1.0.0"}
   "alcotest" {>= "1.7.0" & with-test}
   "mdx" {>= "2.3.0" & with-test}
+  "ocaml-version" {>= "3.6.1" & with-test}
   "domain_shims" {>= "0.1.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.3)
+(lang dune 3.8)
 (name domain-local-await)
 (generate_opam_files true)
 (source (github ocaml-multicore/domain-local-await))
@@ -15,5 +15,6 @@
   (thread-table (>= 1.0.0))
   (alcotest (and (>= 1.7.0) :with-test))
   (mdx (and (>= 2.3.0) :with-test))
+  (ocaml-version (and (>= 3.6.1) :with-test))
   (domain_shims (and (>= 0.1.0) :with-test))))
-(using mdx 0.2)
+(using mdx 0.4)


### PR DESCRIPTION
This PR adds a proof-of-concept implementation of scheduler agnostic and friendly transparently asynchronous  IO.